### PR TITLE
Fix 'template engine' select

### DIFF
--- a/src/components/composables/pdf-rendering.ts
+++ b/src/components/composables/pdf-rendering.ts
@@ -48,6 +48,7 @@ export function usePdfRendering() {
         {
           bundle: zipBlob,
           model: renderTemplateData.modelStr,
+          templateEngine: renderTemplateData.templateEngine,
         },
         {
           loading: false,


### PR DESCRIPTION
Hi!

I noticed that the 'template engine' switch does not work, mainly because the value is never passed to the render function.

Now the switch actually sets the engine chosen to be use as the template render engine.

Correct me if this is not the intended behavior 😃 